### PR TITLE
在多窗口播放的时候，频繁打开关闭容易出现关闭卡住和重复调用player_close的情况，修改了player_close判断是否已关闭，如…

### DIFF
--- a/src/ffplayer.c
+++ b/src/ffplayer.c
@@ -842,7 +842,7 @@ void player_close(void *hplayer)
 {
     PLAYER *player = (PLAYER*)hplayer;
     if (!hplayer) return;
-
+    if (player->close) return;
     // set read_timeout to 0
     player->read_timeout = 0;
 

--- a/src/ffrender.c
+++ b/src/ffrender.c
@@ -299,7 +299,7 @@ static int render_audio_soundtouch(RENDER *render, AVFrame *audio)
 static int render_audio_swresample(RENDER *render, AVFrame *audio)
 {
     int num_samp;
-
+    if (render->status & RENDER_CLOSE) return 0;
     //++ do resample audio data ++//
     num_samp = swr_convert(render->swr_context,
         (uint8_t**)&render->adev_buf_cur, render->adev_buf_avail / 4,


### PR DESCRIPTION
…果已关闭直接跳出。在播放含有音频的视频流时，关闭的时候，偶然情况下会卡在render_audio的while循环中，修改该render_audio_swresample函数，判断当关闭播放后，直接返回0。