### PR TITLE
在播放含有音频的视频流时，关闭的时候，偶然情况下会卡在render_audio的while循环中，增加判断是否已经关闭播放。

### DIFF
--- a/src/ffrender.c
+++ b/src/ffrender.c
@@ -358,7 +358,7 @@ void render_audio(void *hrender, AVFrame *audio)
         {
             sampnum = render_audio_swresample(render, audio);
         }
-    } while (sampnum);
+    } while (sampnum && !(render->status & RENDER_CLOSE));
 }
 
 static float definition_evaluation(uint8_t *img, int w, int h, int stride)


### PR DESCRIPTION
在播放含有音频的视频流时，关闭的时候，偶然情况下会卡在render_audio的while循环中，增加判断是否已经关闭播放。